### PR TITLE
Add client-side scripts and systemd units

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,14 @@ unitdir=$(sysconfdir)/systemd/system
 
 UNITS = \
 	usbipd.service \
-	usbip-device@.service
+	usbip-device@.service \
+	usbip-import@.service
 
 SCRIPTS = \
 	configure-usbip-device.sh \
-	remove-usbip-device.sh
+	remove-usbip-device.sh \
+	attach-usbip-device.sh \
+	detach-usbip-device.sh
 
 all:
 

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ To install the systemd unit, run `make install` in the source
 directory, which will place the support scripts into `/sbin` and the
 systemd unit into `/etc/systemd/system`.
 
-## Configuration
+## Server Configuration
 
 Create one or files in `/etc/usbip-device` named `<device_name>.conf`.
 These files **must** contain the following configuration keys:
 
 
-- `USB_IDVENDOR` -- Vendor ID. 
-- `USB_IDPRODUCT` -- Product ID. 
+- `USB_IDVENDOR` -- Vendor ID.
+- `USB_IDPRODUCT` -- Product ID.
 
 For example, to share a device with vendor:product 03f0:8607, create a file
 called /etc/usbip_devices/mouse.conf
@@ -34,3 +34,36 @@ To share the device immediately:
 To stop sharing it:
 
     systemctl stop usbip-device@mouse
+
+
+## Client Configuration
+
+Client part is configured very similar to server one, with a few additions:
+
+* files in `/etc/usbip-devices` must be named `<device_name>.import.conf`
+* besides `USB_IDVENDOR` and `USB_IDPRODUCT` there should also be `HOST` key, identifying hostname or IP address of the server that shares USB device
+
+Example:
+```
+USB_IDVENDOR=03f0
+USB_IDPRODUCT=8607
+HOST=192.168.1.54
+```
+
+To enable attaching to remote device at boot, run:
+
+```
+systemctl enable usbip-import@mouse
+```
+
+To attach device:
+
+```
+systemctl start usbip-import@mouse
+```
+
+To detach device:
+
+```
+systemctl stop usbip-import@mouse
+```

--- a/attach-usbip-device.sh
+++ b/attach-usbip-device.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+BUS_ID=`usbip list -r ${HOST}|grep ${USB_IDVENDOR}:${USB_IDPRODUCT}|cut -d\: -f 1|xargs`
+[[ -z "$BUS_ID" ]] || /usr/bin/usbip attach -r ${HOST} -b $BUS_ID

--- a/detach-usbip-device.sh
+++ b/detach-usbip-device.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+PORT_ID=`usbip port |awk -F'[ /]+' '/^Port/ { printf $2 } /\(.+:.+\)$/ {printf $NF"#"} /usbip:/ { print $NF}'|grep ${USB_IDVENDOR}:${USB_IDPRODUCT}|cut -d\: -f1`
+[[ -z "$PORT_ID" ]] || /usr/bin/usbip detach -p $PORT_ID

--- a/detach-usbip-device.sh
+++ b/detach-usbip-device.sh
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/bin/bash -e
 PORT_ID=`usbip port |awk -F'[ /]+' '/^Port/ { printf $2 } /\(.+:.+\)$/ {printf $NF"#"} /usbip:/ { print $NF}'|grep ${USB_IDVENDOR}:${USB_IDPRODUCT}|cut -d\: -f1`
 [[ -z "$PORT_ID" ]] || /usr/bin/usbip detach -p $PORT_ID

--- a/remove-usbip-device.sh
+++ b/remove-usbip-device.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash -e
 BUS_ID=`/usr/sbin/usbip list -p -l | grep -i "#usbid=${USB_IDVENDOR}:${USB_IDPRODUCT}#" | cut '-d#' -f1`
 [[ -z "$BUS_ID" ]] || /usr/sbin/usbip unbind --$BUS_ID
 

--- a/usbip-import@.service
+++ b/usbip-import@.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=USB/IP Device import %I
+
+[Service]
+EnvironmentFile=/etc/usbip-devices/%i.import.conf
+RemainAfterExit=yes
+ExecStartPre=/sbin/modprobe vhci_hcd
+ExecStart=/usr/sbin/attach-usbip-device %i
+ExecStop=/usr/sbin/detach-usbip-device %i
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
On client side, it would be really nice to have similar option to automatically attach to remote device.
It works in a very similar way, but requires additional `HOST` variable in configs, and configs should be named `<devce_name>.import.conf`

